### PR TITLE
Chore: Fix the image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ I may be contacted through my <a href="https://chat.nhcarrigan.com" target="_bla
 </p>
 <p align="center">
   <a href="https://chat.nhcarrigan.com" target="_blank" rel="noopener noreferrer">
-    <img src="https://rpc.nhcarrigan.com" />
+    <img src="https://rpc.naomi.lgbt" />
   </a>
 </p>


### PR DESCRIPTION
The image should now point to the real location 

# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

It now correctly points to https://rpc.naomi.lgbt/ instead of https://rpc.nhcarrigan.com/.

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes  #24
